### PR TITLE
Implement Important Minis URL Redirect to Fix Old Broken Links

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -29,6 +29,15 @@ const nextConfig = {
 
         return config;
     },
+    async redirects() {
+        return [
+            {
+                source: '/minis/:slug*',
+                destination: '/projects/:slug*',
+                permanent: true,
+            }
+        ]
+    },
     experimental: {
         serverComponentsExternalPackages: ["mjml"],
     },

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -21,7 +21,7 @@ const AboutMe = () => {
                     >
                         <Image
                             src={dragonOfShuu}
-                            alt={`Dragon of Shuu profile picture art`}
+                            alt={`Dragon of Shuu profile picture`}
                             className={`${styles.profilePic} grow basis-0 min-h-0 max-w-96 object-contain md:w-1/2`}
                         />
                         <h1

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -35,4 +35,5 @@ const config: Config = {
     },
     plugins: [],
 };
+
 export default config;


### PR DESCRIPTION
There are some places that still use `/minis` even though it has now been updated. Created a reroute so they now properly update to `/projects`.